### PR TITLE
Remove accidental dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     },
     "dependencies": {
         "postcss-cli": "^9.0.1",
-        "save-dev": "0.0.1-security",
         "style-dictionary": "^3.0.2"
     },
     "devDependencies": {


### PR DESCRIPTION
This is a holding package that was likely accidentally added. It's a bit of a no-op but good to remove so folks don't copy/paste it into their workflow.